### PR TITLE
Add username length validation to User::validateLogin

### DIFF
--- a/src/classes/User.php
+++ b/src/classes/User.php
@@ -57,6 +57,18 @@
             return $errors;
         }
 
+        public function validateLogin(string $username): bool
+        {
+            $username = trim($username);
+            $length = mb_strlen($username, 'UTF-8');
+
+            if ($length < 3 || $length > 50) {
+                return false;
+            }
+
+            return true;
+        }
+
         public function loginUser(): bool {
 
             // Connect database


### PR DESCRIPTION
## Summary
- trim the provided username before validation in `User::validateLogin`
- ensure the username length is between 3 and 50 characters using a multibyte-safe check

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e65aee0554832995a12c93ee92cd76